### PR TITLE
Redirect www.llmwelcome.dev to bare domain

### DIFF
--- a/lib/llm_welcome_web/endpoint.ex
+++ b/lib/llm_welcome_web/endpoint.ex
@@ -15,6 +15,8 @@ defmodule LlmWelcomeWeb.Endpoint do
     websocket: [connect_info: [session: @session_options]],
     longpoll: [connect_info: [session: @session_options]]
 
+  plug LlmWelcomeWeb.Plugs.RedirectWww
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # When code reloading is disabled (e.g., in production),

--- a/lib/llm_welcome_web/live/home_live.ex
+++ b/lib/llm_welcome_web/live/home_live.ex
@@ -6,7 +6,9 @@ defmodule LlmWelcomeWeb.HomeLive do
   @impl true
   def mount(_params, _session, socket) do
     api_snippet = "curl -s https://llmwelcome.dev/api/issues"
-    agent_prompt = "Read https://llmwelcome.dev/llm-welcome.skill.md and find me an issue to work on"
+
+    agent_prompt =
+      "Read https://llmwelcome.dev/llm-welcome.skill.md and find me an issue to work on"
 
     socket =
       socket
@@ -46,118 +48,121 @@ defmodule LlmWelcomeWeb.HomeLive do
   def render(assigns) do
     ~H"""
     <Layouts.app flash={@flash}>
-    <section class="text-center mb-10">
-      <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight mb-3">
-        Find your first LLM contribution
-      </h1>
-      <p class="text-lg text-base-content/60 max-w-2xl mx-auto">
-        Open source issues curated for LLM-assisted contributors.
-        Pick one, fire up your agent, and ship.
-      </p>
-      <div :if={@total_issues > 0} class="mt-4">
-        <span class="badge badge-primary badge-lg font-semibold">
-          {@total_issues} open {ngettext("issue", "issues", @total_issues)}
-        </span>
-      </div>
-    </section>
-
-    <section class="mb-10 max-w-2xl mx-auto">
-      <div class="card bg-base-200 border border-base-300">
-        <div class="card-body gap-4">
-          <h3 class="card-title text-lg">
-            <.icon name="hero-command-line" class="size-5" /> Get your agent started
-          </h3>
-          <p class="text-sm text-base-content/60">
-            Tell your agent to find you an issue to work on. Just paste this:
-          </p>
-          <div class="space-y-4">
-            <div>
-              <span class="text-xs font-semibold uppercase tracking-wider text-base-content/40">
-                Tell your agent
-              </span>
-              <pre class="mt-1 bg-base-300 rounded-lg px-4 py-3 text-sm overflow-x-auto italic"><code>{@agent_prompt}</code></pre>
-            </div>
-            <div>
-              <span class="text-xs font-semibold uppercase tracking-wider text-base-content/40">
-                Or use the API directly
-              </span>
-              <pre class="mt-1 bg-base-300 rounded-lg px-4 py-3 text-sm overflow-x-auto"><code>{@api_snippet}</code></pre>
-            </div>
-          </div>
-          <p class="text-xs text-base-content/40">
-            <a href={~p"/llm-welcome.skill.md"} class="link link-primary">View the skill file</a>
-            to see exactly what your agent will do.
-          </p>
+      <section class="text-center mb-10">
+        <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight mb-3">
+          Find your first LLM contribution
+        </h1>
+        <p class="text-lg text-base-content/60 max-w-2xl mx-auto">
+          Open source issues curated for LLM-assisted contributors.
+          Pick one, fire up your agent, and ship.
+        </p>
+        <div :if={@total_issues > 0} class="mt-4">
+          <span class="badge badge-primary badge-lg font-semibold">
+            {@total_issues} open {ngettext("issue", "issues", @total_issues)}
+          </span>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section
-      :if={@language_counts != []}
-      class="flex flex-wrap gap-2 justify-center mb-10"
-    >
-      <button
-        :for={{language, count} <- @language_counts}
-        phx-click="filter_language"
-        phx-value-language={language}
-        class={[
-          "badge badge-lg cursor-pointer gap-1.5 transition-colors",
-          if(@selected_language == language, do: "badge-primary", else: "badge-outline hover:badge-neutral")
-        ]}
-      >
-        {language}
-        <span class="opacity-60">{count}</span>
-      </button>
-    </section>
-
-    <section
-      id="repositories"
-      phx-update="stream"
-      class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
-    >
-      <article
-        :for={{dom_id, repo} <- @streams.repositories}
-        id={dom_id}
-        class="card bg-base-200 shadow-sm hover:shadow-md transition-shadow border border-base-300"
-      >
-        <div class="card-body gap-3">
-          <h2 class="card-title text-base">
-            <a
-              href={"https://github.com/#{repo.full_name}"}
-              target="_blank"
-              rel="noopener"
-              class="link link-hover truncate"
-            >
-              <span class="text-base-content/50 font-normal">{repo.owner}/</span>{repo.name}
-            </a>
-          </h2>
-          <p :if={repo.description} class="text-sm text-base-content/60 line-clamp-2">
-            {repo.description}
-          </p>
-          <div class="card-actions items-center mt-auto pt-1 flex-wrap">
-            <span :if={repo.language} class="badge badge-outline badge-sm">{repo.language}</span>
-            <span class="badge badge-ghost badge-sm gap-1">
-              <.icon name="hero-star-micro" class="size-3" /> {repo.stars}
-            </span>
-            <span class="badge badge-primary badge-sm">
-              {repo.issue_count} {ngettext("issue", "issues", repo.issue_count)}
-            </span>
+      <section class="mb-10 max-w-2xl mx-auto">
+        <div class="card bg-base-200 border border-base-300">
+          <div class="card-body gap-4">
+            <h3 class="card-title text-lg">
+              <.icon name="hero-command-line" class="size-5" /> Get your agent started
+            </h3>
+            <p class="text-sm text-base-content/60">
+              Tell your agent to find you an issue to work on. Just paste this:
+            </p>
+            <div class="space-y-4">
+              <div>
+                <span class="text-xs font-semibold uppercase tracking-wider text-base-content/40">
+                  Tell your agent
+                </span>
+                <pre class="mt-1 bg-base-300 rounded-lg px-4 py-3 text-sm overflow-x-auto italic"><code>{@agent_prompt}</code></pre>
+              </div>
+              <div>
+                <span class="text-xs font-semibold uppercase tracking-wider text-base-content/40">
+                  Or use the API directly
+                </span>
+                <pre class="mt-1 bg-base-300 rounded-lg px-4 py-3 text-sm overflow-x-auto"><code>{@api_snippet}</code></pre>
+              </div>
+            </div>
+            <p class="text-xs text-base-content/40">
+              <a href={~p"/llm-welcome.skill.md"} class="link link-primary">View the skill file</a>
+              to see exactly what your agent will do.
+            </p>
           </div>
         </div>
-      </article>
-    </section>
+      </section>
 
-    <section :if={@total_issues == 0} class="text-center py-20">
-      <div class="text-5xl mb-4">
-        <.icon name="hero-code-bracket" class="size-12 opacity-20" />
-      </div>
-      <p class="text-lg font-medium text-base-content/60">No issues yet</p>
-      <p class="text-sm text-base-content/40 mt-1 max-w-md mx-auto">
-        Install the GitHub App and add the
-        <code class="badge badge-outline badge-sm align-middle">llm-welcome</code>
-        label to your issues to get started.
-      </p>
-    </section>
+      <section
+        :if={@language_counts != []}
+        class="flex flex-wrap gap-2 justify-center mb-10"
+      >
+        <button
+          :for={{language, count} <- @language_counts}
+          phx-click="filter_language"
+          phx-value-language={language}
+          class={[
+            "badge badge-lg cursor-pointer gap-1.5 transition-colors",
+            if(@selected_language == language,
+              do: "badge-primary",
+              else: "badge-outline hover:badge-neutral"
+            )
+          ]}
+        >
+          {language}
+          <span class="opacity-60">{count}</span>
+        </button>
+      </section>
+
+      <section
+        id="repositories"
+        phx-update="stream"
+        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
+      >
+        <article
+          :for={{dom_id, repo} <- @streams.repositories}
+          id={dom_id}
+          class="card bg-base-200 shadow-sm hover:shadow-md transition-shadow border border-base-300"
+        >
+          <div class="card-body gap-3">
+            <h2 class="card-title text-base">
+              <a
+                href={"https://github.com/#{repo.full_name}"}
+                target="_blank"
+                rel="noopener"
+                class="link link-hover truncate"
+              >
+                <span class="text-base-content/50 font-normal">{repo.owner}/</span>{repo.name}
+              </a>
+            </h2>
+            <p :if={repo.description} class="text-sm text-base-content/60 line-clamp-2">
+              {repo.description}
+            </p>
+            <div class="card-actions items-center mt-auto pt-1 flex-wrap">
+              <span :if={repo.language} class="badge badge-outline badge-sm">{repo.language}</span>
+              <span class="badge badge-ghost badge-sm gap-1">
+                <.icon name="hero-star-micro" class="size-3" /> {repo.stars}
+              </span>
+              <span class="badge badge-primary badge-sm">
+                {repo.issue_count} {ngettext("issue", "issues", repo.issue_count)}
+              </span>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section :if={@total_issues == 0} class="text-center py-20">
+        <div class="text-5xl mb-4">
+          <.icon name="hero-code-bracket" class="size-12 opacity-20" />
+        </div>
+        <p class="text-lg font-medium text-base-content/60">No issues yet</p>
+        <p class="text-sm text-base-content/40 mt-1 max-w-md mx-auto">
+          Install the GitHub App and add the
+          <code class="badge badge-outline badge-sm align-middle">llm-welcome</code>
+          label to your issues to get started.
+        </p>
+      </section>
     </Layouts.app>
     """
   end

--- a/lib/llm_welcome_web/plugs/redirect_www.ex
+++ b/lib/llm_welcome_web/plugs/redirect_www.ex
@@ -1,0 +1,23 @@
+defmodule LlmWelcomeWeb.Plugs.RedirectWww do
+  @moduledoc """
+  Redirects requests from www subdomain to the bare domain.
+  """
+
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{host: "www." <> rest} = conn, _opts) do
+    url = "#{conn.scheme}://#{rest}#{conn.request_path}#{query_string(conn)}"
+
+    conn
+    |> put_resp_header("location", url)
+    |> send_resp(301, "")
+    |> halt()
+  end
+
+  def call(conn, _opts), do: conn
+
+  defp query_string(%Plug.Conn{query_string: ""}), do: ""
+  defp query_string(%Plug.Conn{query_string: qs}), do: "?#{qs}"
+end

--- a/test/llm_welcome_web/plugs/redirect_www_test.exs
+++ b/test/llm_welcome_web/plugs/redirect_www_test.exs
@@ -1,0 +1,51 @@
+defmodule LlmWelcomeWeb.Plugs.RedirectWwwTest do
+  use ExUnit.Case, async: true
+  import Plug.Test
+  import Plug.Conn
+
+  alias LlmWelcomeWeb.Plugs.RedirectWww
+
+  test "redirects www to bare domain with 301" do
+    conn =
+      conn(:get, "/")
+      |> Map.put(:host, "www.llmwelcome.dev")
+      |> RedirectWww.call([])
+
+    assert conn.status == 301
+    assert get_resp_header(conn, "location") == ["http://llmwelcome.dev/"]
+    assert conn.halted
+  end
+
+  test "preserves path" do
+    conn =
+      conn(:get, "/api/issues")
+      |> Map.put(:host, "www.llmwelcome.dev")
+      |> RedirectWww.call([])
+
+    assert conn.status == 301
+    assert get_resp_header(conn, "location") == ["http://llmwelcome.dev/api/issues"]
+  end
+
+  test "preserves query string" do
+    conn =
+      conn(:get, "/api/issues?language=Elixir")
+      |> Map.put(:host, "www.llmwelcome.dev")
+      |> RedirectWww.call([])
+
+    assert conn.status == 301
+
+    assert get_resp_header(conn, "location") == [
+             "http://llmwelcome.dev/api/issues?language=Elixir"
+           ]
+  end
+
+  test "passes through non-www requests" do
+    conn =
+      conn(:get, "/")
+      |> Map.put(:host, "llmwelcome.dev")
+      |> RedirectWww.call([])
+
+    refute conn.halted
+    refute conn.status
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -33,6 +33,6 @@ defmodule LlmWelcomeWeb.ConnCase do
 
   setup tags do
     LlmWelcome.DataCase.setup_sandbox(tags)
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+    {:ok, conn: Phoenix.ConnTest.build_conn() |> Map.put(:host, "localhost")}
   end
 end


### PR DESCRIPTION
## Summary
- Add `RedirectWww` plug that 301-redirects `www.` requests to the bare domain, preserving path and query string
- Plug is placed early in the endpoint pipeline (before static file serving)
- Set default test host to `localhost` so existing tests aren't affected by the redirect

## Test plan
- [x] 4 unit tests: redirect, path preservation, query string preservation, non-www passthrough
- [x] All 9 existing tests still pass
- [ ] After deploy, verify `curl -I https://www.llmwelcome.dev` returns 301 to `https://llmwelcome.dev`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)