### PR TITLE
Add About section in left column above CTA

### DIFF
--- a/lib/llm_welcome_web/live/about_live.ex
+++ b/lib/llm_welcome_web/live/about_live.ex
@@ -36,27 +36,16 @@ defmodule LlmWelcomeWeb.AboutLive do
         </p>
 
         <p>
-          But there's a gap: most open source projects aren't set up to receive contributions from
-          developers using these tools. And many developers who want to contribute to open source
-          don't know where to start.
+          But many open source projects rightfully frown upon unwelcome LLM-generated contributions.
+          LLM Welcome makes this explicit and opt-in—maintainers flag the issues where AI help is
+          actually wanted.
         </p>
 
         <p>
-          LLM Welcome bridges this gap by:
+          If you have unused API tokens from your coding agent subscription, put them to good use.
+          Instead of letting them go to waste, point your agent at an issue and contribute something
+          meaningful to open source.
         </p>
-
-        <ul>
-          <li>
-            <strong>For contributors:</strong>
-            Curating issues that are well-suited for AI-assisted development—clear scope, good
-            context, and maintainers who are ready to review.
-          </li>
-          <li>
-            <strong>For maintainers:</strong>
-            Providing a way to signal that your project welcomes LLM-assisted contributions and
-            helping you prepare your codebase with agent-friendly documentation.
-          </li>
-        </ul>
 
         <h2>How it works</h2>
 

--- a/lib/llm_welcome_web/live/home_live.ex
+++ b/lib/llm_welcome_web/live/home_live.ex
@@ -64,6 +64,22 @@ defmodule LlmWelcomeWeb.HomeLive do
       <div class="lg:grid lg:grid-cols-5 lg:gap-8">
         <aside class="lg:col-span-2 space-y-4">
           <div class="space-y-4 lg:sticky lg:top-8">
+            <div>
+              <span class="text-xs font-semibold uppercase tracking-[0.2em] text-base-content/50">
+                About
+              </span>
+              <p class="mt-1 text-sm text-base-content/70">
+                Make good use of your unused API tokens. Browse open source issues flagged by
+                maintainers as ready for AI-assisted contributions and have your agent contribute to open source.
+                <.link
+                  navigate={~p"/about"}
+                  class="font-semibold underline transition hover:text-base-content"
+                >
+                  Read more
+                </.link>
+              </p>
+            </div>
+
             <a
               href="https://github.com/apps/llm-welcome"
               target="_blank"


### PR DESCRIPTION
## Summary
- Add a brief About explanation in the home page left sidebar, positioned above the CTA button
- Copy encourages making use of unused API tokens for open source contributions
- Inline "Read more" link navigates to the /about page
- Update About page copy to emphasize opt-in contributions and putting unused agent tokens to good use
- Remove redundant "bridges this gap" section and bullet points from About page

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)