### PR TITLE
Add copy icon to code snippets for easy copy/paste

### DIFF
--- a/lib/llm_welcome_web/components/core_components.ex
+++ b/lib/llm_welcome_web/components/core_components.ex
@@ -419,6 +419,62 @@ defmodule LlmWelcomeWeb.CoreComponents do
   end
 
   @doc """
+  Renders a code block with a copy-to-clipboard button.
+
+  ## Examples
+
+      <.code_block id="my-code" content="some code here" />
+      <.code_block id="prompt" content={@prompt} pre_class="mt-2 bg-neutral text-xs" />
+  """
+  attr :id, :string, required: true
+  attr :content, :string, required: true, doc: "the code text to display"
+  attr :class, :string, default: nil, doc: "additional classes for the wrapper div"
+  attr :pre_class, :string, default: nil, doc: "classes for the <pre> element"
+
+  def code_block(assigns) do
+    ~H"""
+    <div class={["relative", @class]} id={@id} data-code-block>
+      <pre class={@pre_class}><code>{@content}</code></pre>
+      <button
+        phx-hook=".CopyToClipboard"
+        id={"#{@id}-copy-btn"}
+        class="absolute top-1.5 right-1.5 flex items-center justify-center rounded-md p-1 text-neutral-content/40 hover:text-neutral-content transition cursor-pointer"
+        aria-label="Copy to clipboard"
+      >
+        <span data-icon="clipboard"><.icon name="hero-clipboard-document" class="size-4" /></span>
+        <span data-icon="check" class="hidden">
+          <.icon name="hero-clipboard-document-check" class="size-4 text-success" />
+        </span>
+      </button>
+      <script :type={Phoenix.LiveView.ColocatedHook} name=".CopyToClipboard">
+        export default {
+          mounted() {
+            this.el.addEventListener("click", () => {
+              const wrapper = this.el.closest("[data-code-block]")
+              const code = wrapper.querySelector("code")
+              const text = code.textContent.trim()
+
+              navigator.clipboard.writeText(text).then(() => {
+                const clipboardIcon = this.el.querySelector("[data-icon=clipboard]")
+                const checkIcon = this.el.querySelector("[data-icon=check]")
+
+                clipboardIcon.classList.add("hidden")
+                checkIcon.classList.remove("hidden")
+
+                setTimeout(() => {
+                  clipboardIcon.classList.remove("hidden")
+                  checkIcon.classList.add("hidden")
+                }, 2000)
+              })
+            })
+          }
+        }
+      </script>
+    </div>
+    """
+  end
+
+  @doc """
   Renders a [Heroicon](https://heroicons.com).
 
   Heroicons come in three styles – outline, solid, and mini.

--- a/lib/llm_welcome_web/live/about_live.ex
+++ b/lib/llm_welcome_web/live/about_live.ex
@@ -92,14 +92,30 @@ defmodule LlmWelcomeWeb.AboutLive do
           or tell your AI assistant:
         </p>
 
-        <pre><code>Read https://llmwelcome.dev/llm-welcome.skill.md and find me an issue to work on</code></pre>
+        <.code_block
+          id="about-find-issue"
+          content="Read https://llmwelcome.dev/llm-welcome.skill.md and find me an issue to work on"
+          pre_class="pr-8"
+        />
 
         <p>
           <strong>Want to add your project?</strong>
-          Install the GitHub App and tell your AI assistant:
+          <a
+            href="https://github.com/apps/llm-welcome"
+            target="_blank"
+            rel="noopener"
+            class="not-prose inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-primary-content shadow transition hover:bg-primary/90 no-underline"
+          >
+            Install the GitHub App <.icon name="hero-arrow-up-right" class="size-4" />
+          </a>
+          and tell your AI assistant:
         </p>
 
-        <pre><code>Read https://llmwelcome.dev/prepare-for-llm-welcome.skill.md and prepare my project</code></pre>
+        <.code_block
+          id="about-prepare-project"
+          content="Read https://llmwelcome.dev/prepare-for-llm-welcome.skill.md and prepare my project"
+          pre_class="pr-8"
+        />
 
         <h2>Open source</h2>
 

--- a/lib/llm_welcome_web/live/home_live.ex
+++ b/lib/llm_welcome_web/live/home_live.ex
@@ -101,7 +101,12 @@ defmodule LlmWelcomeWeb.HomeLive do
                   <span class="text-xs font-semibold uppercase tracking-[0.2em] text-base-content/50">
                     Tell your agent
                   </span>
-                  <pre class="mt-2 max-w-full whitespace-pre-wrap break-words rounded-xl border border-base-300 bg-neutral px-3 py-2 text-xs text-neutral-content shadow-inner"><code>{@agent_prompt}</code></pre>
+                  <.code_block
+                    id="find-issue-prompt"
+                    content={@agent_prompt}
+                    pre_class="max-w-full whitespace-pre-wrap break-words rounded-xl border border-base-300 bg-neutral px-3 py-2 pr-8 text-xs text-neutral-content shadow-inner"
+                    class="mt-2"
+                  />
                 </div>
                 <div class="card-actions justify-start mt-2">
                   <a
@@ -127,7 +132,12 @@ defmodule LlmWelcomeWeb.HomeLive do
                   <span class="text-xs font-semibold uppercase tracking-[0.2em] text-base-content/50">
                     Tell your agent
                   </span>
-                  <pre class="mt-2 max-w-full whitespace-pre-wrap break-words rounded-xl border border-base-300 bg-neutral px-3 py-2 text-xs text-neutral-content shadow-inner"><code>{@prepare_prompt}</code></pre>
+                  <.code_block
+                    id="prepare-project-prompt"
+                    content={@prepare_prompt}
+                    pre_class="max-w-full whitespace-pre-wrap break-words rounded-xl border border-base-300 bg-neutral px-3 py-2 pr-8 text-xs text-neutral-content shadow-inner"
+                    class="mt-2"
+                  />
                 </div>
                 <div class="card-actions justify-start mt-2">
                   <a


### PR DESCRIPTION
## Summary
- Add a reusable `code_block` component with a copy-to-clipboard button using a colocated LiveView hook
- Copy button visible on all code blocks (home page + about page) with clipboard/checkmark icon feedback
- Make "Install the GitHub App" on the about page a primary CTA button linking to the GitHub App

Closes #6

## Test plan
- [x] Verify copy button appears on all 4 code blocks (2 on home, 2 on about)
- [x] Click copy button and paste — text should be clean with no extra whitespace
- [x] Checkmark icon appears for ~2 seconds after copying, then reverts to clipboard icon
- [x] Works in both light and dark themes
- [x] "Install the GitHub App" button on about page links to https://github.com/apps/llm-welcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)